### PR TITLE
Caching capabilities

### DIFF
--- a/Cache/StrategyCachingCapabilities.php
+++ b/Cache/StrategyCachingCapabilities.php
@@ -33,7 +33,7 @@ trait StrategyCachingCapabilities
      */
     private function setCachedStrategy(string $class, string $key, $strategy): self
     {
-        self::$strategyCache[$class.'::'.$key] = $strategy;
+        self::$strategyCache[$this->getCacheKey($class, $key)] = $strategy;
 
         return $this;
     }
@@ -48,6 +48,6 @@ trait StrategyCachingCapabilities
      */
     private function getCacheKey(string $class, string $key): string
     {
-        return $class.'::'.$key;
+        return $class . '::' . $key;
     }
 }

--- a/Cache/StrategyCachingCapabilities.php
+++ b/Cache/StrategyCachingCapabilities.php
@@ -3,7 +3,7 @@
 namespace Innmind\Reflection\Cache;
 
 /**
- * Strategy caching based on object class and key of method/property
+ * Strategy caching based on object class and key of method/property.
  *
  * @author Hugues Maignol <hugues@hmlb.frr>
  */
@@ -27,11 +27,11 @@ trait StrategyCachingCapabilities
     /**
      * @param string $class
      * @param string $key
-     * @param        $strategy
+     * @param mixed  $strategy
      *
      * @return self
      */
-    private function setCachedStrategy(string $class, string $key, $strategy)
+    private function setCachedStrategy(string $class, string $key, $strategy): self
     {
         self::$strategyCache[$class.'::'.$key] = $strategy;
 
@@ -46,9 +46,8 @@ trait StrategyCachingCapabilities
      *
      * @return string
      */
-    private function getCacheKey(string $class, string $key)
+    private function getCacheKey(string $class, string $key): string
     {
         return $class.'::'.$key;
     }
-
 }

--- a/Cache/StrategyCachingCapabilities.php
+++ b/Cache/StrategyCachingCapabilities.php
@@ -9,7 +9,7 @@ namespace Innmind\Reflection\Cache;
  */
 trait StrategyCachingCapabilities
 {
-    private $strategyCache = [];
+    private static $strategyCache = [];
 
     /**
      * The cached strategy for the given class and property.
@@ -21,7 +21,7 @@ trait StrategyCachingCapabilities
      */
     private function getCachedStrategy(string $class, string $key)
     {
-        return $this->strategyCache[$this->getCacheKey($class, $key)] ?? null;
+        return self::$strategyCache[$this->getCacheKey($class, $key)] ?? null;
     }
 
     /**
@@ -33,7 +33,7 @@ trait StrategyCachingCapabilities
      */
     private function setCachedStrategy(string $class, string $key, $strategy)
     {
-        $this->strategyCache[$class.'::'.$key] = $strategy;
+        self::$strategyCache[$class.'::'.$key] = $strategy;
 
         return $this;
     }

--- a/Cache/StrategyCachingCapabilities.php
+++ b/Cache/StrategyCachingCapabilities.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Innmind\Reflection\Cache;
+
+/**
+ * Strategy caching based on object class and key of method/property
+ *
+ * @author Hugues Maignol <hugues@hmlb.frr>
+ */
+trait StrategyCachingCapabilities
+{
+    private $strategyCache = [];
+
+    /**
+     * The cached strategy for the given class and property.
+     *
+     * @param string $class
+     * @param string $key
+     *
+     * @return mixed|null
+     */
+    private function getCachedStrategy(string $class, string $key)
+    {
+        return $this->strategyCache[$this->getCacheKey($class, $key)] ?? null;
+    }
+
+    /**
+     * @param string $class
+     * @param string $key
+     * @param        $strategy
+     *
+     * @return self
+     */
+    private function setCachedStrategy(string $class, string $key, $strategy)
+    {
+        $this->strategyCache[$class.'::'.$key] = $strategy;
+
+        return $this;
+    }
+
+    /**
+     * Computes cache key for class and property.
+     *
+     * @param string $class
+     * @param string $key
+     *
+     * @return string
+     */
+    private function getCacheKey(string $class, string $key)
+    {
+        return $class.'::'.$key;
+    }
+
+}

--- a/ExtractionStrategy/DefaultExtractionStrategies.php
+++ b/ExtractionStrategy/DefaultExtractionStrategies.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Innmind\Reflection\ExtractionStrategy;
+
+use Innmind\Immutable\TypedCollection;
+use Innmind\Reflection\Cache\StrategyCachingCapabilities;
+use Innmind\Reflection\Exception\LogicException;
+
+/**
+ * DefaultExtractionStrategies
+ *
+ * @author Hugues Maignol <hugues@hmlb.fr>
+ */
+final class DefaultExtractionStrategies implements ExtractionStrategies
+{
+
+    use StrategyCachingCapabilities;
+
+    private $strategies;
+
+    public function all() : TypedCollection
+    {
+        if ($this->strategies == null) {
+            return $this->strategies = new TypedCollection(
+                ExtractionStrategyInterface::class,
+                [
+                    new GetterStrategy,
+                    new NamedMethodStrategy,
+                    new ReflectionStrategy,
+                ]
+            );
+        }
+
+        return $this->strategies;
+    }
+
+    public function get($object, string $key) : ExtractionStrategyInterface
+    {
+        $strategy = $this->getCachedStrategy(get_class($object), $key);
+        if (null !== $strategy) {
+            return $strategy;
+        }
+
+        foreach ($this->all() as $strategy) {
+            if ($strategy->supports($object, $key)) {
+
+                $this->setCachedStrategy(get_class($object), $key, $strategy);
+
+                return $strategy;
+            }
+        }
+
+        throw new LogicException(
+            sprintf(
+                'Property "%s" cannot be extracted',
+                $key
+            )
+        );
+    }
+
+}

--- a/ExtractionStrategy/DefaultExtractionStrategies.php
+++ b/ExtractionStrategy/DefaultExtractionStrategies.php
@@ -3,6 +3,7 @@
 namespace Innmind\Reflection\ExtractionStrategy;
 
 use Innmind\Immutable\TypedCollection;
+use Innmind\Immutable\TypedCollectionInterface;
 use Innmind\Reflection\Cache\StrategyCachingCapabilities;
 use Innmind\Reflection\Exception\LogicException;
 
@@ -18,7 +19,7 @@ final class DefaultExtractionStrategies implements ExtractionStrategies
 
     private $strategies;
 
-    public function all() : TypedCollection
+    public function all(): TypedCollectionInterface
     {
         if ($this->strategies == null) {
             return $this->strategies = new TypedCollection(
@@ -34,7 +35,7 @@ final class DefaultExtractionStrategies implements ExtractionStrategies
         return $this->strategies;
     }
 
-    public function get($object, string $key) : ExtractionStrategyInterface
+    public function get($object, string $key): ExtractionStrategyInterface
     {
         $strategy = $this->getCachedStrategy(get_class($object), $key);
         if (null !== $strategy) {

--- a/ExtractionStrategy/ExtractionStrategies.php
+++ b/ExtractionStrategy/ExtractionStrategies.php
@@ -1,11 +1,8 @@
 <?php
 declare(strict_types = 1);
 
-namespace Innmind\Reflection;
+namespace Innmind\Reflection\ExtractionStrategy;
 
-use Innmind\Reflection\ExtractionStrategy\GetterStrategy;
-use Innmind\Reflection\ExtractionStrategy\NamedMethodStrategy;
-use Innmind\Reflection\ExtractionStrategy\ReflectionStrategy;
 use Innmind\Immutable\TypedCollection;
 use Innmind\Immutable\TypedCollectionInterface;
 

--- a/ExtractionStrategy/ExtractionStrategies.php
+++ b/ExtractionStrategy/ExtractionStrategies.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\ExtractionStrategy;
 
-use Innmind\Immutable\TypedCollection;
+use Innmind\Immutable\TypedCollectionInterface;
 
 /**
  * Repository of extractionStrategies
@@ -15,9 +15,9 @@ interface ExtractionStrategies
     /**
      * All the ExtractionStrategies
      *
-     * @return TypedCollection
+     * @return TypedCollectionInterface
      */
-    public function all() : TypedCollection;
+    public function all(): TypedCollectionInterface;
 
     /**
      * Get the relevant ExctactionStrategyInterface for the given object and key.
@@ -28,5 +28,5 @@ interface ExtractionStrategies
      * @return ExtractionStrategyInterface
      *
      */
-    public function get($object, string $key) : ExtractionStrategyInterface;
+    public function get($object, string $key): ExtractionStrategyInterface;
 }

--- a/ExtractionStrategy/ExtractionStrategies.php
+++ b/ExtractionStrategy/ExtractionStrategies.php
@@ -4,32 +4,29 @@ declare(strict_types = 1);
 namespace Innmind\Reflection\ExtractionStrategy;
 
 use Innmind\Immutable\TypedCollection;
-use Innmind\Immutable\TypedCollectionInterface;
 
-final class ExtractionStrategies
+/**
+ * Repository of extractionStrategies
+ *
+ * @author Hugues Maignol <hugues.maignol@kitpages.fr>
+ */
+interface ExtractionStrategies
 {
-    private static $defaults;
+    /**
+     * All the ExtractionStrategies
+     *
+     * @return TypedCollection
+     */
+    public function all() : TypedCollection;
 
     /**
-     * Return a collection of the default strategies available
+     * Get the relevant ExctactionStrategyInterface for the given object and key.
      *
-     * @return TypedCollectionInterface
+     * @param  mixed $object
+     * @param string $key
+     *
+     * @return ExtractionStrategyInterface
+     *
      */
-    public static function defaults(): TypedCollectionInterface
-    {
-        if (self::$defaults !== null) {
-            return self::$defaults;
-        }
-
-        self::$defaults = new TypedCollection(
-            ExtractionStrategyInterface::class,
-            [
-                new GetterStrategy,
-                new NamedMethodStrategy,
-                new ReflectionStrategy,
-            ]
-        );
-
-        return self::$defaults;
-    }
+    public function get($object, string $key) : ExtractionStrategyInterface;
 }

--- a/ExtractionStrategy/ExtractionStrategyInterface.php
+++ b/ExtractionStrategy/ExtractionStrategyInterface.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Innmind\Reflection;
+namespace Innmind\Reflection\ExtractionStrategy;
 
 interface ExtractionStrategyInterface
 {

--- a/ExtractionStrategy/ExtractionStrategyInterface.php
+++ b/ExtractionStrategy/ExtractionStrategyInterface.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\ExtractionStrategy;
 
+use Innmind\Reflection\Exception\LogicException;
+
 interface ExtractionStrategyInterface
 {
     /**

--- a/ExtractionStrategy/GetterStrategy.php
+++ b/ExtractionStrategy/GetterStrategy.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\ExtractionStrategy;
 
-use Innmind\Reflection\ExtractionStrategyInterface;
 use Innmind\Reflection\Exception\LogicException;
 use Innmind\Immutable\StringPrimitive;
 

--- a/ExtractionStrategy/NamedMethodStrategy.php
+++ b/ExtractionStrategy/NamedMethodStrategy.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\ExtractionStrategy;
 
-use Innmind\Reflection\ExtractionStrategyInterface;
 use Innmind\Reflection\Exception\LogicException;
 use Innmind\Immutable\StringPrimitive;
 

--- a/ExtractionStrategy/ReflectionStrategy.php
+++ b/ExtractionStrategy/ReflectionStrategy.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\ExtractionStrategy;
 
-use Innmind\Reflection\ExtractionStrategyInterface;
 use Innmind\Reflection\Exception\LogicException;
 
 class ReflectionStrategy implements ExtractionStrategyInterface

--- a/InjectionStrategy/DefaultInjectionStrategies.php
+++ b/InjectionStrategy/DefaultInjectionStrategies.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Innmind\Reflection\InjectionStrategy;
+
+use Innmind\Immutable\TypedCollection;
+use Innmind\Reflection\Cache\StrategyCachingCapabilities;
+use Innmind\Reflection\Exception\LogicException;
+
+/**
+ * DefaultInjectionStrategies
+ *
+ * @author Hugues Maignol <hugues@hmlb.fr>
+ */
+final class DefaultInjectionStrategies implements InjectionStrategies
+{
+    use StrategyCachingCapabilities;
+
+    private $strategies;
+
+    public function all() : TypedCollection
+    {
+        if ($this->strategies == null) {
+            return $this->strategies = new TypedCollection(
+                InjectionStrategyInterface::class,
+                [
+                    new SetterStrategy,
+                    new NamedMethodStrategy,
+                    new ReflectionStrategy,
+                ]
+            );
+        }
+
+        return $this->strategies;
+    }
+
+    public function get($object, string $key, $value) : InjectionStrategyInterface
+    {
+        $strategy = $this->getCachedStrategy(get_class($object), $key);
+        if (null !== $strategy) {
+            return $strategy;
+        }
+
+        foreach ($this->all() as $strategy) {
+            if ($strategy->supports($object, $key, $value)) {
+
+                $this->setCachedStrategy(get_class($object), $key, $strategy);
+
+                return $strategy;
+            }
+        }
+
+        throw new LogicException(
+            sprintf(
+                'Property "%s" cannot be injected',
+                $key
+            )
+        );
+    }
+}

--- a/InjectionStrategy/DefaultInjectionStrategies.php
+++ b/InjectionStrategy/DefaultInjectionStrategies.php
@@ -3,6 +3,7 @@
 namespace Innmind\Reflection\InjectionStrategy;
 
 use Innmind\Immutable\TypedCollection;
+use Innmind\Immutable\TypedCollectionInterface;
 use Innmind\Reflection\Cache\StrategyCachingCapabilities;
 use Innmind\Reflection\Exception\LogicException;
 
@@ -17,7 +18,7 @@ final class DefaultInjectionStrategies implements InjectionStrategies
 
     private $strategies;
 
-    public function all() : TypedCollection
+    public function all(): TypedCollectionInterface
     {
         if ($this->strategies == null) {
             return $this->strategies = new TypedCollection(
@@ -33,7 +34,7 @@ final class DefaultInjectionStrategies implements InjectionStrategies
         return $this->strategies;
     }
 
-    public function get($object, string $key, $value) : InjectionStrategyInterface
+    public function get($object, string $key, $value): InjectionStrategyInterface
     {
         $strategy = $this->getCachedStrategy(get_class($object), $key);
         if (null !== $strategy) {

--- a/InjectionStrategy/InjectionStrategies.php
+++ b/InjectionStrategy/InjectionStrategies.php
@@ -4,32 +4,30 @@ declare(strict_types = 1);
 namespace Innmind\Reflection\InjectionStrategy;
 
 use Innmind\Immutable\TypedCollection;
-use Innmind\Immutable\TypedCollectionInterface;
 
-final class InjectionStrategies
+/**
+ * Repository of InjectionStrategies
+ *
+ * @author Hugues Maignol <hugues.maignol@kitpages.fr>
+ */
+interface InjectionStrategies
 {
-    private static $defaults;
 
     /**
-     * Return a collection of the default strategies available
+     * All the InjectionStrategies.
      *
-     * @return TypedCollectionInterface
+     * @return TypedCollection
      */
-    public static function defaults(): TypedCollectionInterface
-    {
-        if (self::$defaults !== null) {
-            return self::$defaults;
-        }
+    public function all() : TypedCollection;
 
-        self::$defaults = new TypedCollection(
-            InjectionStrategyInterface::class,
-            [
-                new SetterStrategy,
-                new NamedMethodStrategy,
-                new ReflectionStrategy,
-            ]
-        );
-
-        return self::$defaults;
-    }
+    /**
+     * Returns the relevant injection strategy for the given object, key and value.
+     *
+     * @param mixed  $object
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return InjectionStrategyInterface
+     */
+    public function get($object, string $key, $value) : InjectionStrategyInterface;
 }

--- a/InjectionStrategy/InjectionStrategies.php
+++ b/InjectionStrategy/InjectionStrategies.php
@@ -1,11 +1,8 @@
 <?php
 declare(strict_types = 1);
 
-namespace Innmind\Reflection;
+namespace Innmind\Reflection\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategy\SetterStrategy;
-use Innmind\Reflection\InjectionStrategy\NamedMethodStrategy;
-use Innmind\Reflection\InjectionStrategy\ReflectionStrategy;
 use Innmind\Immutable\TypedCollection;
 use Innmind\Immutable\TypedCollectionInterface;
 

--- a/InjectionStrategy/InjectionStrategies.php
+++ b/InjectionStrategy/InjectionStrategies.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\InjectionStrategy;
 
-use Innmind\Immutable\TypedCollection;
+use Innmind\Immutable\TypedCollectionInterface;
 
 /**
  * Repository of InjectionStrategies
@@ -16,9 +16,9 @@ interface InjectionStrategies
     /**
      * All the InjectionStrategies.
      *
-     * @return TypedCollection
+     * @return TypedCollectionInterface
      */
-    public function all() : TypedCollection;
+    public function all(): TypedCollectionInterface;
 
     /**
      * Returns the relevant injection strategy for the given object, key and value.
@@ -29,5 +29,5 @@ interface InjectionStrategies
      *
      * @return InjectionStrategyInterface
      */
-    public function get($object, string $key, $value) : InjectionStrategyInterface;
+    public function get($object, string $key, $value): InjectionStrategyInterface;
 }

--- a/InjectionStrategy/InjectionStrategyInterface.php
+++ b/InjectionStrategy/InjectionStrategyInterface.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\InjectionStrategy;
 
+use Innmind\Reflection\Exception\LogicException;
+
 interface InjectionStrategyInterface
 {
     /**

--- a/InjectionStrategy/InjectionStrategyInterface.php
+++ b/InjectionStrategy/InjectionStrategyInterface.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Innmind\Reflection;
+namespace Innmind\Reflection\InjectionStrategy;
 
 interface InjectionStrategyInterface
 {

--- a/InjectionStrategy/NamedMethodStrategy.php
+++ b/InjectionStrategy/NamedMethodStrategy.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategyInterface;
 use Innmind\Reflection\Exception\LogicException;
 use Innmind\Immutable\StringPrimitive;
 

--- a/InjectionStrategy/ReflectionStrategy.php
+++ b/InjectionStrategy/ReflectionStrategy.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategyInterface;
 use Innmind\Reflection\Exception\LogicException;
 
 class ReflectionStrategy implements InjectionStrategyInterface

--- a/InjectionStrategy/SetterStrategy.php
+++ b/InjectionStrategy/SetterStrategy.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategyInterface;
 use Innmind\Reflection\Exception\LogicException;
 use Innmind\Immutable\StringPrimitive;
 

--- a/ReflectionClass.php
+++ b/ReflectionClass.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 namespace Innmind\Reflection;
 
 use Innmind\Reflection\Exception\InvalidArgumentException;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategies;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
 use Innmind\Reflection\Instanciator\ReflectionInstanciator;
 use Innmind\Immutable\Collection;
 use Innmind\Immutable\CollectionInterface;

--- a/ReflectionClass.php
+++ b/ReflectionClass.php
@@ -109,7 +109,7 @@ class ReflectionClass
         $properties = $this
             ->properties
             ->filter(
-                function ($value, $property) use ($parameters) {
+                function($value, $property) use ($parameters) {
                     return !$parameters->contains($property);
                 }
             );

--- a/ReflectionClass.php
+++ b/ReflectionClass.php
@@ -3,12 +3,11 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection;
 
+use Innmind\Immutable\Collection;
+use Innmind\Immutable\CollectionInterface;
 use Innmind\Reflection\InjectionStrategy\DefaultInjectionStrategies;
 use Innmind\Reflection\InjectionStrategy\InjectionStrategies;
 use Innmind\Reflection\Instanciator\ReflectionInstanciator;
-use Innmind\Immutable\Collection;
-use Innmind\Immutable\CollectionInterface;
-use Innmind\Immutable\TypedCollectionInterface;
 
 class ReflectionClass
 {
@@ -35,7 +34,7 @@ class ReflectionClass
      * Add a property to be injected in the new object
      *
      * @param string $property
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return self
      */
@@ -109,9 +108,11 @@ class ReflectionClass
         //avoid injecting the properties already used in the constructor
         $properties = $this
             ->properties
-            ->filter(function($value, $property) use ($parameters) {
-                return !$parameters->contains($property);
-            });
+            ->filter(
+                function ($value, $property) use ($parameters) {
+                    return !$parameters->contains($property);
+                }
+            );
         $refl = new ReflectionObject(
             $object,
             $properties,

--- a/ReflectionClass.php
+++ b/ReflectionClass.php
@@ -3,9 +3,8 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection;
 
-use Innmind\Reflection\Exception\InvalidArgumentException;
+use Innmind\Reflection\InjectionStrategy\DefaultInjectionStrategies;
 use Innmind\Reflection\InjectionStrategy\InjectionStrategies;
-use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
 use Innmind\Reflection\Instanciator\ReflectionInstanciator;
 use Innmind\Immutable\Collection;
 use Innmind\Immutable\CollectionInterface;
@@ -21,14 +20,10 @@ class ReflectionClass
     public function __construct(
         string $class,
         CollectionInterface $properties = null,
-        TypedCollectionInterface $injectionStrategies = null,
+        InjectionStrategies $injectionStrategies = null,
         InstanciatorInterface $instanciator = null
     ) {
-        $injectionStrategies = $injectionStrategies ?? InjectionStrategies::defaults();
-
-        if ($injectionStrategies->getType() !== InjectionStrategyInterface::class) {
-            throw new InvalidArgumentException;
-        }
+        $injectionStrategies = $injectionStrategies ?? new DefaultInjectionStrategies();
 
         $this->class = $class;
         $this->properties = $properties ?? new Collection([]);
@@ -84,9 +79,9 @@ class ReflectionClass
     /**
      * Return the list of injection strategies used
      *
-     * @return TypedCollectionInterface
+     * @return InjectionStrategies
      */
-    public function getInjectionStrategies(): TypedCollectionInterface
+    public function getInjectionStrategies(): InjectionStrategies
     {
         return $this->injectionStrategies;
     }

--- a/ReflectionObject.php
+++ b/ReflectionObject.php
@@ -8,6 +8,10 @@ use Innmind\Reflection\Exception\LogicException;
 use Innmind\Immutable\Collection;
 use Innmind\Immutable\CollectionInterface;
 use Innmind\Immutable\TypedCollectionInterface;
+use Innmind\Reflection\ExtractionStrategy\ExtractionStrategies;
+use Innmind\Reflection\ExtractionStrategy\ExtractionStrategyInterface;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategies;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
 
 class ReflectionObject
 {

--- a/ReflectionObject.php
+++ b/ReflectionObject.php
@@ -5,7 +5,6 @@ namespace Innmind\Reflection;
 
 use Innmind\Immutable\Collection;
 use Innmind\Immutable\CollectionInterface;
-use Innmind\Immutable\TypedCollectionInterface;
 use Innmind\Reflection\Exception\InvalidArgumentException;
 use Innmind\Reflection\ExtractionStrategy\DefaultExtractionStrategies;
 use Innmind\Reflection\ExtractionStrategy\ExtractionStrategies;
@@ -41,7 +40,7 @@ class ReflectionObject
      * Add a property that will be injected
      *
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return self
      */
@@ -161,7 +160,7 @@ class ReflectionObject
     {
         return $this
             ->extractionStrategies
-            ->get($this->object,$property)
-            ->extract($this->object,$property);
+            ->get($this->object, $property)
+            ->extract($this->object, $property);
     }
 }

--- a/Tests/Cache/CacheTestObject.php
+++ b/Tests/Cache/CacheTestObject.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Reflection\Tests\Cache;
+
+/**
+ * CacheTestObject
+ *
+ * @author Hugues Maignol <hugues@hmlb.fr>
+ */
+class CacheTestObject
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+}

--- a/Tests/Cache/StrategyCachingCapabilitiesTest.php
+++ b/Tests/Cache/StrategyCachingCapabilitiesTest.php
@@ -22,11 +22,12 @@ class StrategyCachingCapabilitiesTest extends \PHPUnit_Framework_TestCase
 
         //Strategy should not be already cached for CacheTestObject
         $cachedStrategies = $this->getCachedStrategies($extractionStrategies);
-        foreach($cachedStrategies as $key => $strategy){
+        foreach ($cachedStrategies as $key => $strategy) {
             $this->assertFalse($key == 'Innmind\Reflection\Tests\Cache\CacheTestObject::name');
         }
 
-        $firstTime = $reflection->extract(['name']);
+        $firstTime = $reflection->extract(['name'])['name'];
+        $this->assertEquals('unicorn', $firstTime);
 
         //Strategy should now be cached for CacheTestObject::name
         $cachedStrategies = $this->getCachedStrategies($extractionStrategies);
@@ -36,15 +37,20 @@ class StrategyCachingCapabilitiesTest extends \PHPUnit_Framework_TestCase
             $cachedStrategies['Innmind\Reflection\Tests\Cache\CacheTestObject::name']
         );
 
-        $secondTime = $reflection->extract(['name']);
+        $secondReflection = new ReflectionObject($object);
+        $secondExtractionStrategies = $secondReflection->getExtractionStrategies();
 
         //Strategy should still be cached for CacheTestObject::name and returned strategies should be equal.
-        $cachedStrategies = $this->getCachedStrategies($extractionStrategies);
-        $this->assertArrayHasKey('Innmind\Reflection\Tests\Cache\CacheTestObject::name', $cachedStrategies);
+        $secondCachedStrategies = $this->getCachedStrategies($secondExtractionStrategies);
+        $this->assertArrayHasKey('Innmind\Reflection\Tests\Cache\CacheTestObject::name', $secondCachedStrategies);
         $this->assertInstanceOf(
             ReflectionStrategy::class,
-            $cachedStrategies['Innmind\Reflection\Tests\Cache\CacheTestObject::name']
+            $secondCachedStrategies['Innmind\Reflection\Tests\Cache\CacheTestObject::name']
         );
+        $this->assertEquals($cachedStrategies, $secondCachedStrategies);
+
+        $secondTime = $secondReflection->extract(['name'])['name'];
+
         $this->assertEquals($firstTime, $secondTime);
     }
 

--- a/Tests/Cache/StrategyCachingCapabilitiesTest.php
+++ b/Tests/Cache/StrategyCachingCapabilitiesTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Reflection\Tests\Cache;
+
+use Innmind\Reflection\ExtractionStrategy\ReflectionStrategy;
+use Innmind\Reflection\ReflectionObject;
+
+/**
+ * StrategyCachingCapabilitiesTest
+ *
+ * @author Hugues Maignol <hugues@hmlb.fr>
+ */
+class StrategyCachingCapabilitiesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCaching()
+    {
+        $object = new CacheTestObject('unicorn');
+        $reflection = new ReflectionObject($object);
+
+        $extractionStrategies = $reflection->getExtractionStrategies();
+
+        //Strategy should not be already cached for CacheTestObject
+        $cachedStrategies = $this->getCachedStrategies($extractionStrategies);
+        foreach($cachedStrategies as $key => $strategy){
+            $this->assertFalse($key == 'Innmind\Reflection\Tests\Cache\CacheTestObject::name');
+        }
+
+        $firstTime = $reflection->extract(['name']);
+
+        //Strategy should now be cached for CacheTestObject::name
+        $cachedStrategies = $this->getCachedStrategies($extractionStrategies);
+        $this->assertArrayHasKey('Innmind\Reflection\Tests\Cache\CacheTestObject::name', $cachedStrategies);
+        $this->assertInstanceOf(
+            ReflectionStrategy::class,
+            $cachedStrategies['Innmind\Reflection\Tests\Cache\CacheTestObject::name']
+        );
+
+        $secondTime = $reflection->extract(['name']);
+
+        //Strategy should still be cached for CacheTestObject::name and returned strategies should be equal.
+        $cachedStrategies = $this->getCachedStrategies($extractionStrategies);
+        $this->assertArrayHasKey('Innmind\Reflection\Tests\Cache\CacheTestObject::name', $cachedStrategies);
+        $this->assertInstanceOf(
+            ReflectionStrategy::class,
+            $cachedStrategies['Innmind\Reflection\Tests\Cache\CacheTestObject::name']
+        );
+        $this->assertEquals($firstTime, $secondTime);
+    }
+
+    private function getCachedStrategies($strategyCache)
+    {
+        $reflection = new \ReflectionClass($strategyCache);
+        $property = $reflection->getProperty('strategyCache');
+        $property->setAccessible(true);
+        $cache = $property->getValue($strategyCache);
+        $property->setAccessible(false);
+
+        return $cache;
+    }
+}

--- a/Tests/ExtractionStrategiesTest.php
+++ b/Tests/ExtractionStrategiesTest.php
@@ -3,8 +3,8 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\Tests;
 
-use Innmind\Reflection\ExtractionStrategies;
-use Innmind\Reflection\ExtractionStrategyInterface;
+use Innmind\Reflection\ExtractionStrategy\ExtractionStrategies;
+use Innmind\Reflection\ExtractionStrategy\ExtractionStrategyInterface;
 use Innmind\Reflection\ExtractionStrategy\GetterStrategy;
 use Innmind\Reflection\ExtractionStrategy\NamedMethodStrategy;
 use Innmind\Reflection\ExtractionStrategy\ReflectionStrategy;

--- a/Tests/ExtractionStrategy/DefaultExtractionStrategiesTest.php
+++ b/Tests/ExtractionStrategy/DefaultExtractionStrategiesTest.php
@@ -1,26 +1,25 @@
 <?php
 declare(strict_types = 1);
 
-namespace Innmind\Reflection\Tests;
+namespace Innmind\Reflection\Tests\ExtractionStrategy;
 
-use Innmind\Reflection\ExtractionStrategy\ExtractionStrategies;
+use Innmind\Reflection\ExtractionStrategy\DefaultExtractionStrategies;
 use Innmind\Reflection\ExtractionStrategy\ExtractionStrategyInterface;
 use Innmind\Reflection\ExtractionStrategy\GetterStrategy;
 use Innmind\Reflection\ExtractionStrategy\NamedMethodStrategy;
 use Innmind\Reflection\ExtractionStrategy\ReflectionStrategy;
 use Innmind\Immutable\TypedCollection;
 
-class ExtractionStrategiesTest extends \PHPUnit_Framework_TestCase
+class DefaultExtractionStrategiesTest extends \PHPUnit_Framework_TestCase
 {
     public function testDefaults()
     {
-        $defaults = ExtractionStrategies::defaults();
+        $defaults = (new DefaultExtractionStrategies())->all();
 
         $this->assertInstanceOf(TypedCollection::class, $defaults);
         $this->assertSame(ExtractionStrategyInterface::class, $defaults->getType());
         $this->assertInstanceOf(GetterStrategy::class, $defaults[0]);
         $this->assertInstanceOf(NamedMethodStrategy::class, $defaults[1]);
         $this->assertInstanceOf(ReflectionStrategy::class, $defaults[2]);
-        $this->assertSame($defaults, ExtractionStrategies::defaults());
     }
 }

--- a/Tests/InjectionStrategiesTest.php
+++ b/Tests/InjectionStrategiesTest.php
@@ -3,8 +3,8 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\Tests;
 
-use Innmind\Reflection\InjectionStrategies;
-use Innmind\Reflection\InjectionStrategyInterface;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategies;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
 use Innmind\Reflection\InjectionStrategy\SetterStrategy;
 use Innmind\Reflection\InjectionStrategy\NamedMethodStrategy;
 use Innmind\Reflection\InjectionStrategy\ReflectionStrategy;

--- a/Tests/InjectionStrategy/DefaultInjectionStrategiesTest.php
+++ b/Tests/InjectionStrategy/DefaultInjectionStrategiesTest.php
@@ -1,26 +1,25 @@
 <?php
 declare(strict_types = 1);
 
-namespace Innmind\Reflection\Tests;
+namespace Innmind\Reflection\Tests\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategy\InjectionStrategies;
+use Innmind\Reflection\InjectionStrategy\DefaultInjectionStrategies;
 use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
 use Innmind\Reflection\InjectionStrategy\SetterStrategy;
 use Innmind\Reflection\InjectionStrategy\NamedMethodStrategy;
 use Innmind\Reflection\InjectionStrategy\ReflectionStrategy;
 use Innmind\Immutable\TypedCollection;
 
-class InjectionStrategiesTest extends \PHPUnit_Framework_TestCase
+class DefaultInjectionStrategiesTest extends \PHPUnit_Framework_TestCase
 {
     public function testDefaults()
     {
-        $defaults = InjectionStrategies::defaults();
+        $defaults = (new DefaultInjectionStrategies())->all();
 
         $this->assertInstanceOf(TypedCollection::class, $defaults);
         $this->assertSame(InjectionStrategyInterface::class, $defaults->getType());
         $this->assertInstanceOf(SetterStrategy::class, $defaults[0]);
         $this->assertInstanceOf(NamedMethodStrategy::class, $defaults[1]);
         $this->assertInstanceOf(ReflectionStrategy::class, $defaults[2]);
-        $this->assertSame($defaults, InjectionStrategies::defaults());
     }
 }

--- a/Tests/InjectionStrategy/NamedMethodStrategyTest.php
+++ b/Tests/InjectionStrategy/NamedMethodStrategyTest.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\Tests\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategyInterface;
 use Innmind\Reflection\InjectionStrategy\NamedMethodStrategy;
 
 class NamedMethodStrategyTest extends \PHPUnit_Framework_TestCase

--- a/Tests/InjectionStrategy/ReflectionStrategyTest.php
+++ b/Tests/InjectionStrategy/ReflectionStrategyTest.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\Tests\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategyInterface;
 use Innmind\Reflection\InjectionStrategy\ReflectionStrategy;
 
 class ReflectionStrategyTest extends \PHPUnit_Framework_TestCase

--- a/Tests/InjectionStrategy/SetterStrategyTest.php
+++ b/Tests/InjectionStrategy/SetterStrategyTest.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\Tests\InjectionStrategy;
 
-use Innmind\Reflection\InjectionStrategyInterface;
 use Innmind\Reflection\InjectionStrategy\SetterStrategy;
 
 class SetterStrategyTest extends \PHPUnit_Framework_TestCase

--- a/Tests/ReflectionClassTest.php
+++ b/Tests/ReflectionClassTest.php
@@ -3,15 +3,16 @@ declare(strict_types = 1);
 
 namespace Innmind\Reflection\Tests;
 
-use Innmind\Reflection\ReflectionClass;
+use Innmind\Immutable\CollectionInterface;
+use Innmind\Immutable\TypedCollection;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategies;
 use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
-use Innmind\Reflection\InjectionStrategy\SetterStrategy;
 use Innmind\Reflection\InjectionStrategy\NamedMethodStrategy;
 use Innmind\Reflection\InjectionStrategy\ReflectionStrategy;
-use Innmind\Reflection\InstanciatorInterface;
+use Innmind\Reflection\InjectionStrategy\SetterStrategy;
 use Innmind\Reflection\Instanciator\ReflectionInstanciator;
-use Innmind\Immutable\TypedCollection;
-use Innmind\Immutable\CollectionInterface;
+use Innmind\Reflection\InstanciatorInterface;
+use Innmind\Reflection\ReflectionClass;
 
 class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,10 +36,12 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(42, $o->a());
 
         $o = (new ReflectionClass(WithConstruct::class))
-            ->withProperties([
-                'a' => 24,
-                'b' => 66,
-            ])
+            ->withProperties(
+                [
+                    'a' => 24,
+                    'b' => 66,
+                ]
+            )
             ->buildObject();
 
         $this->assertInstanceOf(WithConstruct::class, $o);
@@ -50,21 +53,31 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
     {
         $refl = new ReflectionClass('stdClass');
 
-        $s = $refl->getInjectionStrategies();
+        $s = $refl->getInjectionStrategies()->all();
         $this->assertSame(InjectionStrategyInterface::class, $s->getType());
         $this->assertInstanceOf(SetterStrategy::class, $s[0]);
         $this->assertInstanceOf(NamedMethodStrategy::class, $s[1]);
         $this->assertInstanceOf(ReflectionStrategy::class, $s[2]);
 
+        $testInjectionStrategies = $this->getMockBuilder(InjectionStrategies::class)
+            ->getMock();
+        $testInjectionStrategies->expects($this->any())
+            ->method('all')
+            ->will(
+                $this->returnValue(
+                    new TypedCollection(
+                        InjectionStrategyInterface::class,
+                        [$s = new ReflectionStrategy]
+                    )
+                )
+            );
+
         $refl = new ReflectionClass(
             'stdClass',
             null,
-            new TypedCollection(
-                InjectionStrategyInterface::class,
-                [$s = new ReflectionStrategy]
-            )
+            $testInjectionStrategies
         );
-        $this->assertSame($s, $refl->getInjectionStrategies()[0]);
+        $this->assertSame($s, $refl->getInjectionStrategies()->all()[0]);
     }
 
     public function testGetProperties()
@@ -84,7 +97,8 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $i = $r->getInstanciator();
         $this->assertInstanceOf(ReflectionInstanciator::class, $i);
 
-        $i = new class implements InstanciatorInterface {
+        $i = new class implements InstanciatorInterface
+        {
             public function build(string $class, CollectionInterface $properties)
             {
             }

--- a/Tests/ReflectionClassTest.php
+++ b/Tests/ReflectionClassTest.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\Reflection\Tests;
 
 use Innmind\Reflection\ReflectionClass;
-use Innmind\Reflection\InjectionStrategyInterface;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
 use Innmind\Reflection\InjectionStrategy\SetterStrategy;
 use Innmind\Reflection\InjectionStrategy\NamedMethodStrategy;
 use Innmind\Reflection\InjectionStrategy\ReflectionStrategy;

--- a/Tests/ReflectionObjectTest.php
+++ b/Tests/ReflectionObjectTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 namespace Innmind\Reflection\Tests;
 
 use Innmind\Reflection\ReflectionObject;
-use Innmind\Reflection\InjectionStrategyInterface;
+use Innmind\Reflection\InjectionStrategy\InjectionStrategyInterface;
 use Innmind\Reflection\InjectionStrategy\SetterStrategy;
 use Innmind\Reflection\InjectionStrategy\NamedMethodStrategy;
 use Innmind\Reflection\InjectionStrategy\ReflectionStrategy;
-use Innmind\Reflection\ExtractionStrategyInterface;
+use Innmind\Reflection\ExtractionStrategy\ExtractionStrategyInterface;
 use Innmind\Reflection\ExtractionStrategy\GetterStrategy;
 use Innmind\Reflection\ExtractionStrategy\NamedMethodStrategy as ENamedMethodStrategy;
 use Innmind\Reflection\ExtractionStrategy\ReflectionStrategy as EReflectionStrategy;


### PR DESCRIPTION
This MR changes the inner workings of the library without changing the API of ReflectionClass and ReflectionObject.  
The choice of the strategy to use for injection/extraction is delegated to services that can cache the processing for better performances, specially when injecting data to collection of objects of the same class.
