### PR TITLE
Using the assertNull to assert result is null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-    - '7.4snapshot'
+    - '7.4'
     - nightly
 matrix:
     allow_failures:

--- a/tests/ReflectionClassTest.php
+++ b/tests/ReflectionClassTest.php
@@ -30,7 +30,7 @@ class ReflectionClassTest extends TestCase
         $o = $r->build();
 
         $this->assertInstanceOf(NoConstructor::class, $o);
-        $this->assertSame(null, $o->a());
+        $this->assertNull($o->a());
     }
 
     public function testBuild()


### PR DESCRIPTION
# Changed log

- Using the `assertNull` to assert result type is null.